### PR TITLE
python3-sphinx：1.6.3 -> 1.6.6.

### DIFF
--- a/classes/dosocs.bbclass
+++ b/classes/dosocs.bbclass
@@ -54,8 +54,8 @@ python do_spdx () {
     else:
         return None
 
-    ## gcc is too big to get spdx file.
-    if 'gcc' in d.getVar('PN', True):
+    ## gcc and kernel is too big to get spdx file.
+    if 'gcc' or 'linux-yocto' in d.getVar('PN', True):
         return None 
     
     info = {} 
@@ -131,8 +131,8 @@ python do_get_spdx_s() {
     if d.getVar('PN', True) == d.getVar('BPN', True) + "-native":
         return None
 
-    ## gcc is too big to get spdx file.
-    if 'gcc' in d.getVar('PN', True):
+    ## gcc and kernel is too big to get spdx file.
+    if 'gcc' or 'linux-yocto' in d.getVar('PN', True):
         return None
 
     # Forcibly expand the sysroot paths as we're about to change WORKDIR

--- a/recipes-devtools/python/python3-sphinx-native_1.6.6.bb
+++ b/recipes-devtools/python/python3-sphinx-native_1.6.6.bb
@@ -2,15 +2,15 @@ DESCRIPTION = "Python documentation generator"
 HOMEPAGE = "http://sphinx-doc.org/"
 SECTION = "devel/python"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=bdf5e5254e389241208655de56611028"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d5575c977f2e4659ece47f731f2b8319"
 
 PR = "r0"
 SRCNAME = "sphinx"
 
 SRC_URI = "https://github.com/sphinx-doc/sphinx/archive/${PV}.tar.gz"
 
-SRC_URI[md5sum] = "4cb791d4ec15c0116940e7f6c27d7aef"
-SRC_URI[sha256sum] = "0707b2a8a47462c06b0107426b8512a68332232241e414384b6b86cce9b7f60f"
+SRC_URI[md5sum] = "567457f488771643ea4d8adffacc6b2a"
+SRC_URI[sha256sum] = "1ce2041ef4538eba0dc8394a5add4a97fbfa54f026322ae4a7e6fb2c2ea51ae7"
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"
 


### PR DESCRIPTION
1) Upgrade python3-sphinx from 1.6.3 to 1.6.6.

2) License checksum is changed as the year is changed in license file.

Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>