### PR TITLE
scancode-toolkit: Remove wrong install command

### DIFF
--- a/recipes-devtools/scancode-toolkit/scancode-toolkit-native_3.1.1.bb
+++ b/recipes-devtools/scancode-toolkit/scancode-toolkit-native_3.1.1.bb
@@ -35,6 +35,5 @@ do_install_append(){
 
 	install ${S}/scancode ${D}${bindir}/
 	install ${S}/bin/* ${D}${bindir}/bin/
-	mv ${S}/include/* ${D}${bindir}/include/
 }
 


### PR DESCRIPTION
This command causes error since there's no "include" folder